### PR TITLE
Refactor plugin config for lolcommits v0.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,14 @@ cache: bundler
 rvm:
  - 2.0.0
  - 2.1.10
- - 2.2.8
- - 2.3.5
- - 2.4.2
+ - 2.2.9
+ - 2.3.6
+ - 2.4.3
+ - 2.5.0
  - ruby-head
 
 before_install:
- - gem install bundler -v 1.13.7
+ - gem update --system
  - git --version
  - git config --global user.email "lol@commits.org"
  - git config --global user.name "Lolcommits"

--- a/lib/lolcommits/flowdock/version.rb
+++ b/lib/lolcommits/flowdock/version.rb
@@ -1,5 +1,5 @@
 module Lolcommits
   module Flowdock
-    VERSION = "0.0.2".freeze
+    VERSION = "0.0.3".freeze
   end
 end

--- a/lib/lolcommits/plugin/flowdock.rb
+++ b/lib/lolcommits/plugin/flowdock.rb
@@ -104,7 +104,7 @@ module Lolcommits
           nil
         else
           puts "\nEnter your Flowdock organization name (tab to autocomplete, Ctrl+c cancels)"
-          prompt_autocomplete_hash("Organization: ", orgs)
+          prompt_autocomplete_hash("Organization: ", orgs, value: "parameterized_name")
         end
       end
 
@@ -115,28 +115,7 @@ module Lolcommits
           nil
         else
           puts "\nEnter your Flowdock flow name (tab to autocomplete, Ctrl+c cancels)"
-          prompt_autocomplete_hash("Flow: ", flows)
-        end
-      end
-
-      def prompt_autocomplete_hash(prompt, items, name: 'name', value: 'parameterized_name', suggest_words: 5)
-        words = items.map {|item| item[name] }.sort
-        puts "e.g. #{words.take(suggest_words).join(", ")}" if suggest_words > 0
-        completed_input = gets_autocomplete(prompt, words)
-        items.find { |item| item[name] == completed_input }[value]
-      end
-
-      def gets_autocomplete(prompt, words)
-        completion_handler = proc { |s| words.grep(/^#{Regexp.escape(s)}/) }
-        Readline.completion_append_character = ""
-        Readline.completion_proc = completion_handler
-
-        while line = Readline.readline(prompt, true).strip
-          if words.include?(line)
-            return line
-          else
-            puts "'#{line}' not found"
-          end
+          prompt_autocomplete_hash("Flow: ", flows, value: "parameterized_name")
         end
       end
 

--- a/lib/lolcommits/plugin/flowdock.rb
+++ b/lib/lolcommits/plugin/flowdock.rb
@@ -8,15 +8,6 @@ module Lolcommits
     class Flowdock < Base
 
       ##
-      # Returns the name of the plugin. Identifies the plugin to lolcommits.
-      #
-      # @return [String] the plugin name
-      #
-      def self.name
-        'flowdock'
-      end
-
-      ##
       # Returns position(s) of when this plugin should run during the capture
       # process. Posting to Flowdock happens when a new capture is ready.
       #
@@ -24,18 +15,6 @@ module Lolcommits
       #
       def self.runner_order
         [:capture_ready]
-      end
-
-      ##
-      # Returns true if the plugin has been configured. An access token,
-      # organization and flow must be set.
-      #
-      # @return [Boolean] true/false indicating if plugin is configured
-      #
-      def configured?
-        !!(configuration['access_token'] &&
-           configuration['organization'] &&
-           configuration['flow'])
       end
 
       ##
@@ -47,7 +26,7 @@ module Lolcommits
       #
       def configure_options!
         options = super
-        if options['enabled']
+        if options[:enabled]
           puts "\nCopy (or create) your Flowdock personal API token (paste it below)"
           open_url("https://flowdock.com/account/tokens")
           print "API token: "
@@ -59,9 +38,9 @@ module Lolcommits
           raise Interrupt unless flow && organization
 
           options.merge!(
-            'access_token' => access_token,
-            'flow'         => flow,
-            'organization' => organization
+            access_token: access_token,
+            flow: flow,
+            organization: organization
           )
         end
 
@@ -78,8 +57,8 @@ module Lolcommits
       def run_capture_ready
         print "Posting to Flowdock ... "
         message = flowdock.create_message(
-          organization: configuration['organization'],
-          flow: configuration['flow'],
+          organization: configuration[:organization],
+          flow: configuration[:flow],
           params: {
             event: 'file',
             content: File.new(runner.main_image),
@@ -125,7 +104,7 @@ module Lolcommits
 
       def flowdock
         @flowdock ||= Lolcommits::Flowdock::Client.new(
-          configuration['access_token']
+          configuration[:access_token]
         )
       end
     end

--- a/lolcommits-flowdock.gemspec
+++ b/lolcommits-flowdock.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "rest-client"
 
-  spec.add_development_dependency "lolcommits", ">= 0.9.8"
+  spec.add_development_dependency "lolcommits", ">= 0.10.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "pry"

--- a/test/lolcommits/plugin/flowdock_test.rb
+++ b/test/lolcommits/plugin/flowdock_test.rb
@@ -6,14 +6,6 @@ describe Lolcommits::Plugin::Flowdock do
   include Lolcommits::TestHelpers::GitRepo
   include Lolcommits::TestHelpers::FakeIO
 
-  def plugin_name
-    "flowdock"
-  end
-
-  it "should have a name" do
-    ::Lolcommits::Plugin::Flowdock.name.must_equal plugin_name
-  end
-
   it "should run on capture ready" do
     ::Lolcommits::Plugin::Flowdock.runner_order.must_equal [:capture_ready]
   end
@@ -31,28 +23,22 @@ describe Lolcommits::Plugin::Flowdock do
       @plugin ||= Lolcommits::Plugin::Flowdock.new(runner: runner)
     end
 
-    def valid_enabled_config
-      @config ||= OpenStruct.new(
-        read_configuration: { "flowdock" => flowdock_config }
-      )
-    end
-
-    def flowdock_config
+    def plugin_config
       {
-        "enabled"      => true,
-        "access_token" => "f4f6aa86fd747a00e75238810412x543",
-        'organization' => 'myorg',
-        'flow'         => 'myflow'
+        enabled: true,
+        access_token: "f4f6aa86fd747a00e75238810412x543",
+        organization: "myorg",
+        flow: "myflow"
       }
     end
 
     describe "#enabled?" do
-      it "is false by default" do
-        plugin.enabled?.must_equal false
+      it "is not enabled by default" do
+        assert_nil plugin.enabled?
       end
 
       it "is true when configured" do
-        plugin.config = valid_enabled_config
+        plugin.configuration = plugin_config
         plugin.enabled?.must_equal true
       end
     end
@@ -63,8 +49,8 @@ describe Lolcommits::Plugin::Flowdock do
 
       it "posts lolcommit as a new file message to Flowdock" do
         in_repo do
-          plugin.config = valid_enabled_config
-          message_url = "https://api.flowdock.com/flows/#{flowdock_config['organization']}/#{flowdock_config['flow']}/messages"
+          plugin.configuration = plugin_config
+          message_url = "https://api.flowdock.com/flows/#{plugin_config[:organization]}/#{plugin_config[:flow]}/messages"
           valid_response = { id: "123", event: "file", tags: ["lolcommits"]}
 
           stub_request(:post, message_url).to_return(status: 200, body: valid_response.to_json)
@@ -86,15 +72,6 @@ describe Lolcommits::Plugin::Flowdock do
     end
 
     describe "configuration" do
-      it "returns false when not configured" do
-        plugin.configured?.must_equal false
-      end
-
-      it "returns true when configured" do
-        plugin.config = valid_enabled_config
-        plugin.configured?.must_equal true
-      end
-
       it "allows plugin options to be configured" do
         # enabled, access token, organization and flow
         access_token = "mytoken"
@@ -129,10 +106,10 @@ describe Lolcommits::Plugin::Flowdock do
         output.must_match(/e.g. Flowtwo, My Flow/)
 
         configured_plugin_options.must_equal({
-          "enabled"      => true,
-          "access_token" => access_token,
-          "organization" => "myorgparam",
-          "flow"         => "myflowparam"
+          enabled: true,
+          access_token: access_token,
+          organization: "myorgparam",
+          flow: "myflowparam"
         })
       end
     end


### PR DESCRIPTION
refactor plugin config for lolcommits v0.10.0

* require at least lolcommits >= 0.10.0
* drop`self.name` method, plugins are now identified by their gem name
* drop calls to `configured?` (no longer available)
* change `configure_options!` to use tabbed auto-complete helper and switch to symbol keys
* bump gem version
* update rubies, add 2.5.0, fix before install